### PR TITLE
lint: Use iwyu to sanitizer header includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,8 @@ AlwaysBreakTemplateDeclarations: Yes
 
 InsertNewlineAtEOF: true
 
+AlignTrailingComments: Leave
+
 IncludeIsMainRegex: "(_test)?$"
 IncludeBlocks: Regroup
 SortIncludes: true

--- a/.github/workflows/backwalk-ci.yml
+++ b/.github/workflows/backwalk-ci.yml
@@ -43,11 +43,29 @@ jobs:
     - name: Install dependencies
       run: ./tools/install-deps.sh
 
-    - name: Generate Build System
+    - name: Generate build system
       run: cmake -B ${{github.workspace}}/build
 
     - name: Run clang-tidy
       run: cmake --build ${{github.workspace}}/build -t lint
+
+  headers:
+    runs-on: ${{matrix.os}}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: ./tools/install-deps.sh
+
+    - name: Generate build system
+      run: cmake -B ${{github.workspace}}/build -DBW_IWYU=ON
+
+    - name: Run iwyu
+      run: cmake --build ${{github.workspace}}/build -t iwyu
 
   build:
     runs-on: ${{matrix.os}}
@@ -62,7 +80,7 @@ jobs:
     - name: Install dependencies
       run: ./tools/install-deps.sh
 
-    - name: Generate Build System
+    - name: Generate build system
       run: |
         if [ "${{ matrix.compiler }}" = "clang" ]; then
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ set(BACKWALK_SRC_LIST
     ${CMAKE_CURRENT_BINARY_DIR}/gen/version.c
 )
 
+file(GLOB_RECURSE ASM_FILES "${BACKWALK_SRC_DIR}/asm/*")
+message(${ASM_FILES})
+if (BW_IWYU)
+    list(REMOVE_ITEM BACKWALK_SRC_LIST ${ASM_FILES})
+endif()
+
+
 add_library(backwalk ${BACKWALK_SRC_LIST})
 target_include_directories(backwalk PUBLIC ${BACKWALK_INCLUDE_DIR})
 if (BW_DEBUG_ENABLED)
@@ -80,4 +87,22 @@ add_custom_target(lint
 add_custom_target(fmt
   COMMAND git clang-format --diff
   COMMENT "Running clang-format..."
+)
+
+add_custom_target(iwyu
+  COMMAND iwyu_tool -p ${CMAKE_BINARY_DIR} --
+  -Xiwyu --check_also=${BACKWALK_SRC_DIR}/*.h
+  -Xiwyu --check_also=${BACKWALK_TEST_DIR}/*.h
+  -Xiwyu --update_comments
+  -Xiwyu --error=1
+  COMMENT "Running iwyu..."
+)
+
+add_custom_target(iwyu-fix
+  COMMAND iwyu_tool -p ${CMAKE_BINARY_DIR} --
+  -Xiwyu --check_also=${BACKWALK_SRC_DIR}/*.h
+  -Xiwyu --check_also=${BACKWALK_TEST_DIR}/*.h
+  -Xiwyu --update_comments
+  | fix_include --update_comments --nosafe_headers --noreorder
+  COMMENT "Running iwyu and applying suggestions..."
 )

--- a/include/backwalk/backwalk.h
+++ b/include/backwalk/backwalk.h
@@ -1,8 +1,8 @@
 #ifndef BW_BACKWALK_H
 #define BW_BACKWALK_H
 
-#include <stdbool.h>
-#include <stdint.h>
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for uintptr_t
 
 typedef bool (*bw_backtrace_cb)(uintptr_t addr, const char* fname, const char* sname, void* arg);
 

--- a/src/backwalk.c
+++ b/src/backwalk.c
@@ -2,12 +2,13 @@
 #define _GNU_SOURCE
 #include "backwalk/backwalk.h"
 
-#include <dlfcn.h>
-#include <stddef.h>
-#include <stdint.h>
+#include <dlfcn.h>    // for dladdr, Dl_info
+#include <stdbool.h>  // for bool, false, true
+#include <stddef.h>   // for NULL
+#include <stdint.h>   // for uintptr_t
 
-#include "context.h"
-#include "debug.h"
+#include "context.h"  // for context_get_ip, context_init, context_step, con...
+#include "debug.h"    // for BW_DEBUG_ENABLED
 
 bool bw_backtrace(bw_backtrace_cb cb, void* arg) {
     context_t ctx;

--- a/src/context.c
+++ b/src/context.c
@@ -1,5 +1,5 @@
 #if defined(__x86_64__)
-#include "context_x64.inc"
+#include "context_x64.inc" // IWYU pragma: keep
 #else
 #error "unsupported platform"
 #endif // defined(__x86_64__)

--- a/src/context.h
+++ b/src/context.h
@@ -1,8 +1,8 @@
 #ifndef BW_CONTEXT_H
 #define BW_CONTEXT_H
 
-#include <stdbool.h>
-#include <stdint.h>
+#include <stdbool.h>  // for bool
+#include <stdint.h>   // for uintptr_t
 
 enum { CONTEXT_DATA_LEN = 8 };
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -6,10 +6,10 @@
 #endif
 
 #if BW_DEBUG_ENABLED
-#include <stdint.h>
-#include <stdio.h>
+#include <stdint.h>  // for uintptr_t
+#include <stdio.h>   // for fprintf, stderr
 
-#include "common.h"
+#include "common.h"  // for BW_UNUSED
 
 void print_frame(int fnum, uintptr_t addr, const char* fname, const char* sname) {
     BW_UNUSED(fprintf(stderr, "#%2d [%#08jx] %s:%s\n", fnum, addr, fname, sname));

--- a/test/noinline_test.c
+++ b/test/noinline_test.c
@@ -1,13 +1,12 @@
-#include <stdbool.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+#include <stdbool.h>            // for bool, false, true
+#include <stddef.h>             // for size_t
+#include <stdint.h>             // for uintptr_t
+#include <string.h>             // for strcmp
 
-#include "common.h"
-#include "backwalk/backwalk.h"
+#include "common.h"             // for BW_UNUSED
+#include "backwalk/backwalk.h"  // for bw_backtrace
 
-#include "test.h"
+#include "test.h"               // for TEST, TEST_ASSERT_GE_INT, TEST_ASSERT...
 
 #define MK_SNAME_EXP(ctx, i, fname)                                                                \
     do {                                                                                           \

--- a/test/test.h
+++ b/test/test.h
@@ -1,9 +1,10 @@
 #ifndef BW_TEST_COMMON_H
 #define BW_TEST_COMMON_H
 
-#include <stdio.h>
+#include <stdbool.h>  // for true
+#include <stdio.h>    // for fprintf, stderr, NULL
 
-#include "common.h"
+#include "common.h"   // for BW_UNUSED
 
 typedef enum {
     TEST_RESULT_OK = 0,

--- a/test/version_test.c
+++ b/test/version_test.c
@@ -1,8 +1,6 @@
 #include "backwalk/version.h"
 
-#include <stddef.h>
-
-#include "test.h"
+#include "test.h"  // for TEST, TEST_ASSERT_NE_CHAR, TEST_ASSERT_NONNULL
 
 TEST(populated) {
     const char* version = bw_version();

--- a/tools/install-deps.sh
+++ b/tools/install-deps.sh
@@ -3,7 +3,11 @@ set -eux
 
 sudo apt-get update
 
-sudo apt-get install -y clang-19 clang-format-19 clang-tidy-19
+sudo apt-get install -y \
+    clang-19 \
+    clang-format-19 \
+    clang-tidy-19 \
+    iwyu
 
 sudo ln -sf /usr/bin/clang-19 /usr/bin/clang
 sudo ln -sf /usr/bin/clang-format-19 /usr/bin/clang-format


### PR DESCRIPTION
The tool will run as part of the 'lint' step in CI. Two new build targets are included:
- iwyu: reports header includes violations.
- iywu-fix: Attempts to fix reported violations.