### PR TITLE
core: Add aarch64 support on Linux

### DIFF
--- a/.github/workflows/backwalk-ci.yml
+++ b/.github/workflows/backwalk-ci.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
 
     steps:
     - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
 
     steps:
     - uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, ubuntu-24.04-arm ]
         compiler: [ gcc, clang ]
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ configure_file(${BACKWALK_SRC_DIR}/version.c.in ${CMAKE_CURRENT_BINARY_DIR}/gen/
 set(BACKWALK_SRC_LIST
     ${BACKWALK_SRC_DIR}/backwalk.c
     ${BACKWALK_SRC_DIR}/context.c
+    ${BACKWALK_SRC_DIR}/asm/context_aarch64.S
     ${BACKWALK_SRC_DIR}/asm/context_x64.S
     ${CMAKE_CURRENT_BINARY_DIR}/gen/version.c
 )

--- a/src/asm/context_aarch64.S
+++ b/src/asm/context_aarch64.S
@@ -1,0 +1,16 @@
+#if defined(__aarch64__)
+
+.text
+.globl context_init
+.type context_init, %function
+context_init:
+    # Stack base for caller
+    str  x29, [x0]
+
+    # Where we're returning to
+    ldr  x9, [x29]
+    str  x9, [x0, #8]
+
+    ret
+
+#endif // defined(__aarch64__)

--- a/src/context.c
+++ b/src/context.c
@@ -1,5 +1,7 @@
 #if defined(__x86_64__)
 #include "context_x64.inc" // IWYU pragma: keep
+#elif defined(__aarch64__)
+#include "context_aarch64.inc" // IWYU pragma: keep
 #else
 #error "unsupported platform"
 #endif // defined(__x86_64__)

--- a/src/context_aarch64.inc
+++ b/src/context_aarch64.inc
@@ -1,0 +1,27 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "context.h"
+
+bool context_step(context_t* ctx) {
+    // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    uintptr_t* base = (uintptr_t*)ctx->data[0];
+
+    if (base == NULL) {
+        return false;
+    }
+
+    if (*base == ctx->data[0]) {
+        return false;
+    }
+
+    ctx->data[0] = *base;
+    ctx->data[1] = *(base + 1);
+
+    return true;
+}
+
+uintptr_t context_get_ip(context_t* ctx) {
+    return ctx->data[1];
+}


### PR DESCRIPTION
The implementation follows the approach of x86-64: traverse the linked list of frame pointers and assume that the return address is pushed onto the stack.