### PR TITLE
test: Improve TEST_ERROR macro usage

### DIFF
--- a/test/backtrace_test.c
+++ b/test/backtrace_test.c
@@ -58,7 +58,7 @@ TEST(basic_backtrace, {
     bool success = bw_backtrace(count_frames_cb, &ctx);
 
     TEST_ASSERT_TRUE(success);
-    TEST_ASSERT_GE_INT(ctx.frame_count, 1);
+    TEST_ASSERT_GE_INT32(ctx.frame_count, 1);
     TEST_ASSERT_TRUE(ctx.found_expected_func);
 })
 
@@ -69,7 +69,7 @@ TEST(deep_stack_backtrace, {
     bool success = deep_function_1(&ctx);
 
     TEST_ASSERT_TRUE(success);
-    TEST_ASSERT_GE_INT(ctx.frame_count, 3); // Should have at least a few frames
+    TEST_ASSERT_GE_INT32(ctx.frame_count, 3); // Should have at least a few frames
     // Note: Function name visibility depends on debug symbols and optimization
     BW_UNUSED(ctx.found_expected_func); // Don't assert on this - it's implementation dependent
 })
@@ -80,7 +80,7 @@ TEST(early_termination, {
     bool success = bw_backtrace(stop_after_n_frames_cb, &frame_count);
 
     TEST_ASSERT_FALSE(success); // Returns false since callback stops after 3 frames
-    TEST_ASSERT_EQ_INT(frame_count, 3); // Should stop after exactly 3 frames
+    TEST_ASSERT_EQ_INT32(frame_count, 3); // Should stop after exactly 3 frames
 })
 
 TEST(null_callback, {
@@ -113,7 +113,7 @@ TEST(symbol_resolution, {
     bool success = bw_backtrace(collect_symbols_cb, &valid_symbols);
 
     TEST_ASSERT_TRUE(success);
-    TEST_ASSERT_GE_INT(valid_symbols, 1); // Should have at least some valid symbols
+    TEST_ASSERT_GE_INT32(valid_symbols, 1); // Should have at least some valid symbols
 })
 
 int main(void) {

--- a/test/edge_cases_test.c
+++ b/test/edge_cases_test.c
@@ -6,7 +6,7 @@
 #include "common.h"             // for BW_UNUSED
 #include "backwalk/backwalk.h"  // for bw_backtrace
 
-#include "test.h"               // for TEST, TEST_RUN, TEST_ASSERT_GE_INT
+#include "test.h"               // for TEST, TEST_RUN, TEST_ASSERT_GE_INT32
 
 // Test callback that always returns false (stops immediately)
 bool stop_immediately_cb(uintptr_t addr, const char* fname, const char* sname, void* arg) {
@@ -82,7 +82,7 @@ TEST(immediate_stop_callback, {
 
     // bw_backtrace returns false when callback returns false (early termination)
     TEST_ASSERT_FALSE(success); // Should return false since callback stops immediately
-    TEST_ASSERT_EQ_INT(call_count, 1); // Should be called exactly once
+    TEST_ASSERT_EQ_INT32(call_count, 1); // Should be called exactly once
 })
 
 TEST(null_fname_sname_handling, {
@@ -97,12 +97,12 @@ TEST(null_fname_sname_handling, {
     bool success = bw_backtrace(track_nulls_cb, &stats);
 
     TEST_ASSERT_TRUE(success);
-    TEST_ASSERT_GE_INT(stats.total_calls, 1);
+    TEST_ASSERT_GE_INT32(stats.total_calls, 1);
 
     // Some fname/sname might be null or empty - this is implementation dependent
     // Just ensure we don't crash and get some reasonable data
-    TEST_ASSERT_GE_INT(stats.total_calls, stats.null_fname + stats.empty_fname);
-    TEST_ASSERT_GE_INT(stats.total_calls, stats.null_sname + stats.empty_sname);
+    TEST_ASSERT_GE_INT32(stats.total_calls, stats.null_fname + stats.empty_fname);
+    TEST_ASSERT_GE_INT32(stats.total_calls, stats.null_sname + stats.empty_sname);
 })
 
 TEST(very_deep_stack, {
@@ -113,7 +113,7 @@ TEST(very_deep_stack, {
     bool success = deep_recursion(recursion_depth, &max_frames);
 
     TEST_ASSERT_TRUE(success); // Returns true since count_all_frames_cb counts all frames
-    TEST_ASSERT_GE_INT(max_frames, recursion_depth); // Should see at least the recursive depth
+    TEST_ASSERT_GE_INT32(max_frames, recursion_depth); // Should see at least the recursive depth
 })
 
 // Test with different callback argument types
@@ -169,7 +169,7 @@ TEST(callback_modifies_arg, {
     bool success = bw_backtrace(modify_arg_cb, &value);
 
     TEST_ASSERT_TRUE(success); // Returns false since callback returns false
-    TEST_ASSERT_GE_INT(value, 5 + expected_increment); // Should be modified by callback
+    TEST_ASSERT_GE_INT32(value, 5 + expected_increment); // Should be modified by callback
 })
 
 // Test with function pointers and indirect calls

--- a/test/noinline_test.c
+++ b/test/noinline_test.c
@@ -6,7 +6,7 @@
 #include "common.h"             // for BW_UNUSED
 #include "backwalk/backwalk.h"  // for bw_backtrace
 
-#include "test.h"               // for TEST, TEST_ASSERT_GE_INT, TEST_ASSERT...
+#include "test.h"               // for TEST, TEST_ASSERT_GE_INT32, TEST_ASSE...
 
 #define MK_SNAME_EXP(ctx, i, fname)                                                                \
     do {                                                                                           \
@@ -52,7 +52,7 @@ TEST(success, {
     MK_SNAME_EXP(ctx, 2, "success");
 
     bool success = func_one(&ctx);
-    TEST_ASSERT_GE_INT(ctx.fnum, ctx.fnum_max);
+    TEST_ASSERT_GE_INT32(ctx.fnum, ctx.fnum_max);
     TEST_ASSERT_TRUE(success);
 })
 

--- a/test/test.h
+++ b/test/test.h
@@ -1,10 +1,11 @@
 #ifndef BW_TEST_COMMON_H
 #define BW_TEST_COMMON_H
 
-#include <stdbool.h>  // for true, false
-#include <stdio.h>    // for fprintf, stderr, NULL
+#include <inttypes.h>  // for PRId32, PRId64
+#include <stdbool.h>   // for true, false
+#include <stdio.h>     // for fprintf, stderr, NULL
 
-#include "common.h"   // for BW_UNUSED
+#include "common.h"    // for BW_UNUSED
 
 typedef enum {
     TEST_RESULT_OK = 0,
@@ -46,7 +47,7 @@ typedef enum {
 
 #define TEST_RUN(test_function)                                                                    \
     do {                                                                                           \
-        BW_UNUSED(fprintf(stderr, "RUN: %s." #test_function "\n", TEST_SUITENAME_));               \
+        BW_UNUSED(fprintf(stderr, "RUN: %s.%s\n", TEST_SUITENAME_, #test_function));               \
         TEST_RESULT_ test_result = (test_function)();                                              \
         TEST_FINAL_RESULT_UPDATE_(test_result);                                                    \
         const char* result_str = NULL;                                                             \
@@ -64,7 +65,7 @@ typedef enum {
             result_str = "UNKNOWN";                                                                \
         }                                                                                          \
         BW_UNUSED(                                                                                 \
-            fprintf(stderr, "END: %s." #test_function " %s\n\n", TEST_SUITENAME_, result_str));    \
+            fprintf(stderr, "END: %s.%s %s\n\n", TEST_SUITENAME_, #test_function, result_str));    \
     } while (0)
 
 #define TEST(test_name, test_body)                                                                 \
@@ -73,37 +74,23 @@ typedef enum {
         TEST_OK();                                                                                 \
     }
 
-#define TEST_LOG(fmt, ...)                                                                         \
+#define TEST_LOG_(fmt, ...)                                                                        \
     do {                                                                                           \
         int res =                                                                                  \
             fprintf(stderr, "%s:%d\n\t" fmt "\n", __FILE__, __LINE__ __VA_OPT__(, ) __VA_ARGS__);  \
         BW_UNUSED(res);                                                                            \
     } while (0)
 
-#define TEST_ASSERT_OP_(val, exp, cond, op, fmt)                                                   \
-    do {                                                                                           \
-        if (!(cond)) {                                                                             \
-            TEST_LOG("assertion failed: %s " op " %s\n"                                            \
-                     "\tactual: " fmt "\n"                                                         \
-                     "\texpected: " fmt,                                                           \
-                     #val,                                                                         \
-                     #exp,                                                                         \
-                     (val),                                                                        \
-                     (exp));                                                                       \
-            return TEST_RESULT_FAIL;                                                               \
-        }                                                                                          \
-    } while (0)
-
 #define TEST_ASSERT_EQ_BOOL_(val, exp)                                                             \
     do {                                                                                           \
         if ((val) != (exp)) {                                                                      \
-            TEST_LOG("assertion failed: %s == %s\n"                                                \
-                     "\tactual: %s \n"                                                             \
-                     "\texpected: %s",                                                             \
-                     #val,                                                                         \
-                     #exp,                                                                         \
-                     (val) ? "true" : "false",                                                     \
-                     (exp) ? "true" : "false");                                                    \
+            TEST_LOG_("assertion failed: %s == %s\n"                                               \
+                      "\tactual:   %s\n"                                                           \
+                      "\texpected: %s",                                                            \
+                      #val,                                                                        \
+                      #exp,                                                                        \
+                      (val) ? "true" : "false",                                                    \
+                      (exp) ? "true" : "false");                                                   \
             return TEST_RESULT_FAIL;                                                               \
         }                                                                                          \
     } while (0)
@@ -114,24 +101,51 @@ typedef enum {
 #define TEST_ASSERT_NONNULL(expr)                                                                  \
     do {                                                                                           \
         if ((expr) == NULL) {                                                                      \
-            TEST_LOG("assertion failed: %s != NULL", #expr);                                       \
+            TEST_LOG_("assertion failed: %s != NULL", #expr);                                      \
+            return TEST_RESULT_FAIL;                                                               \
+        }                                                                                          \
+    } while (0)
+
+#define TEST_ASSERT_OP_(val, exp, cond, op, fmt)                                                   \
+    do {                                                                                           \
+        if (!(cond)) {                                                                             \
+            TEST_LOG_("assertion failed: %s %s %s\n"                                               \
+                      "\tactual:   " fmt "\n"                                                      \
+                      "\texpected: " fmt,                                                          \
+                      #val,                                                                        \
+                      op,                                                                          \
+                      #exp,                                                                        \
+                      val,                                                                         \
+                      exp);                                                                        \
             return TEST_RESULT_FAIL;                                                               \
         }                                                                                          \
     } while (0)
 
 #define TEST_ASSERT_EQ_(val, exp, fmt) TEST_ASSERT_OP_(val, exp, (val) == (exp), "==", fmt)
-#define TEST_ASSERT_EQ_INT(val, exp) TEST_ASSERT_EQ_(val, exp, "%d")
+#define TEST_ASSERT_EQ_INT32(val, exp) TEST_ASSERT_EQ_(val, exp, "%" PRId32)
 #define TEST_ASSERT_EQ_CHAR(val, exp) TEST_ASSERT_EQ_(val, exp, "%c")
 
 #define TEST_ASSERT_NE_(val, exp, fmt) TEST_ASSERT_OP_(val, exp, (val) != (exp), "!=", fmt)
 #define TEST_ASSERT_NE_CHAR(val, exp) TEST_ASSERT_NE_(val, exp, "%c")
 
-#define TEST_ASSERT_GE_INT(val, exp) TEST_ASSERT_OP_(val, exp, (val) >= (exp), ">=", "%d")
+#define TEST_ASSERT_GE_(val, exp, fmt) TEST_ASSERT_OP_(val, exp, (val) >= (exp), ">=", fmt)
+#define TEST_ASSERT_GE_INT32(val, exp) TEST_ASSERT_GE_(val, exp, "%" PRId32)
+#define TEST_ASSERT_GE_INT64(val, exp) TEST_ASSERT_GE_(val, exp, "%" PRId64)
+
+#define TEST_ASSERT_LE_(val, exp, fmt) TEST_ASSERT_OP_(val, exp, (val) <= (exp), "<=", fmt)
+#define TEST_ASSERT_LE_INT32(val, exp) TEST_ASSERT_LE_(val, exp, "%" PRId32)
+#define TEST_ASSERT_LE_INT64(val, exp) TEST_ASSERT_LE_(val, exp, "%" PRId64)
 
 #define TEST_OK() return TEST_RESULT_OK
 
 #define TEST_FAIL() return TEST_RESULT_FAIL
 
-#define TEST_ERROR() return TEST_RESULT_ERR
+#define TEST_ERROR_NONZERO(expr)                                                                   \
+    do {                                                                                           \
+        if ((expr) != 0) {                                                                         \
+            TEST_LOG_("test error: %s == 0\n\tactual: %" PRId32 "\n", #expr, expr);                \
+            return TEST_RESULT_ERR;                                                                \
+        }                                                                                          \
+    } while (0)
 
 #endif // BW_TEST_COMMON_H


### PR DESCRIPTION
Implement TEST_ERROR_NONZERO to return early with TEST_RESULT_ERROR if the expression is non-zero. TEST_RESULT_ERROR communicates a failure in the test support code rather than a failure to maintain an invariant.