### PR TITLE
debug: Support symbol demangling for C++

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,6 +15,7 @@ Checks: >
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-macro-usage
   -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
 
 ExcludeHeaderFilterRegex: "benchmark/.*"
 WarningsAsErrors: "*"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ configure_file(${BACKWALK_SRC_DIR}/version.c.in ${CMAKE_CURRENT_BINARY_DIR}/gen/
 set(BACKWALK_SRC_LIST
     ${BACKWALK_SRC_DIR}/backwalk.c
     ${BACKWALK_SRC_DIR}/context.c
+    ${BACKWALK_SRC_DIR}/debug.c
     ${BACKWALK_SRC_DIR}/asm/context_aarch64.S
     ${BACKWALK_SRC_DIR}/asm/context_x64.S
     ${CMAKE_CURRENT_BINARY_DIR}/gen/version.c

--- a/src/backwalk.c
+++ b/src/backwalk.c
@@ -8,15 +8,11 @@
 #include <stdint.h>   // for uintptr_t
 
 #include "context.h"  // for context_get_ip, context_init, context_step, con...
-#include "debug.h"    // for BW_DEBUG_ENABLED
+#include "debug.h"    // for BW_PRINT_FRAME
 
 bool bw_backtrace(bw_backtrace_cb cb, void* arg) {
     context_t ctx;
     context_init(&ctx);
-
-#if BW_DEBUG_ENABLED
-    int fnum = 0;
-#endif
 
     while (context_step(&ctx)) {
         uintptr_t ip = context_get_ip(&ctx);
@@ -32,10 +28,8 @@ bool bw_backtrace(bw_backtrace_cb cb, void* arg) {
         fname = info.dli_fname ? info.dli_fname : "?";
         sname = info.dli_sname ? info.dli_sname : "?";
 
-#if BW_DEBUG_ENABLED
-        print_frame(fnum, mod_addr, fname, sname);
-        ++fnum;
-#endif
+        BW_PRINT_FRAME(mod_addr, fname, sname);
+
         if (cb && !cb(mod_addr, fname, sname, arg)) {
             return false;
         }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,25 @@
+#include "debug.h"
+
+#include <stdint.h>  // for uintptr_t
+#include <stdio.h>   // for NULL, fprintf, stderr
+
+#include "common.h"  // for BW_UNUSED
+
+__attribute__((weak)) char* bw_dbg_demangle(const char* sname);
+__attribute__((weak)) void bw_dbg_demangle_free(const char* sname);
+
+void print_frame(uintptr_t addr, const char* fname, const char* sname) {
+    char* demangled_sname = NULL;
+    if (bw_dbg_demangle != NULL) {
+        demangled_sname = bw_dbg_demangle(sname);
+        if (demangled_sname != NULL) {
+            sname = demangled_sname;
+        }
+    }
+
+    BW_UNUSED(fprintf(stderr, "[%#08jx] %s:%s\n", addr, fname, sname));
+
+    if (bw_dbg_demangle_free != NULL && demangled_sname != NULL) {
+        bw_dbg_demangle_free(demangled_sname);
+    }
+}

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,19 +1,21 @@
 #ifndef BW_DEBUG_H
 #define BW_DEBUG_H
 
+#include <stdint.h>  // for uintptr_t
+
 #if !defined(BW_DEBUG_ENABLED)
 #define BW_DEBUG_ENABLED 0
-#endif
+#endif // BW_DEBUG_ENABLED
+
+void print_frame(uintptr_t addr, const char* fname, const char* sname);
 
 #if BW_DEBUG_ENABLED
-#include <stdint.h>  // for uintptr_t
-#include <stdio.h>   // for fprintf, stderr
-
-#include "common.h"  // for BW_UNUSED
-
-void print_frame(int fnum, uintptr_t addr, const char* fname, const char* sname) {
-    BW_UNUSED(fprintf(stderr, "#%2d [%#08jx] %s:%s\n", fnum, addr, fname, sname));
-}
+#define BW_PRINT_FRAME(addr, fname, sname)                                                         \
+    do {                                                                                           \
+        print_frame(addr, fname, sname);                                                           \
+    } while (0)
+#else
+#define BW_PRINT_FRAME(addr, fname, sname)
 
 #endif // BW_DEBUG_ENABLED
 


### PR DESCRIPTION
Provide a pair of weak symbols that can be overridden by applications to demangle C++ symbols.