### PR TITLE
test: Support test filtering

### DIFF
--- a/test/backtrace_test.c
+++ b/test/backtrace_test.c
@@ -141,8 +141,8 @@ TEST(symbol_resolution, {
     TEST_ASSERT_GE_INT32(valid_symbols, 1); // Should have at least some valid symbols
 })
 
-int main(void) {
-    TEST_INIT("backtrace");
+int main(int argc, char** argv) {
+    TEST_INIT("backtrace", argc, argv);
 
     TEST_RUN(basic_backtrace);
     TEST_RUN(deep_stack_backtrace);

--- a/test/cpp_test.cpp
+++ b/test/cpp_test.cpp
@@ -117,8 +117,8 @@ void bw_dbg_demangle_free(char* sname) {
 }
 }
 
-int main(void) {
-    TEST_INIT("cpp");
+int main(int argc, char** argv) {
+    TEST_INIT("cpp", argc, argv);
 
     TEST_RUN(test_ns::test_backtrace);
     TEST_RUN(test_ns::test_lambda_in_callstack);

--- a/test/edge_cases_test.c
+++ b/test/edge_cases_test.c
@@ -192,8 +192,8 @@ TEST(function_pointer_backtrace, {
     TEST_ASSERT_FALSE(success); // Returns false since stop_immediately_cb returns false
 })
 
-int main(void) {
-    TEST_INIT("edge_cases");
+int main(int argc, char** argv) {
+    TEST_INIT("edge_cases", argc, argv);
 
     TEST_RUN(immediate_stop_callback);
     TEST_RUN(null_fname_sname_handling);

--- a/test/stress_test.c
+++ b/test/stress_test.c
@@ -136,8 +136,8 @@ TEST(memory_stability, {
     }
 })
 
-int main(void) {
-    TEST_INIT("stress");
+int main(int argc, char** argv) {
+    TEST_INIT("stress", argc, argv);
 
     TEST_RUN(repeated_backtrace_calls);
     TEST_RUN(backtrace_performance_basic);

--- a/test/threading_test.c
+++ b/test/threading_test.c
@@ -298,8 +298,8 @@ TEST(thread_local_data_collection, {
     }
 })
 
-int main(void) {
-    TEST_INIT("threading");
+int main(int argc, char** argv) {
+    TEST_INIT("threading", argc, argv);
 
     TEST_RUN(basic_multithreaded_backtrace);
     TEST_RUN(recursive_multithreaded_backtrace);

--- a/test/version_test.c
+++ b/test/version_test.c
@@ -8,8 +8,8 @@ TEST(populated, {
     TEST_ASSERT_NE_CHAR(version[0], '\0');
 })
 
-int main(void) {
-    TEST_INIT("version");
+int main(int argc, char** argv) {
+    TEST_INIT("version", argc, argv);
 
     TEST_RUN(populated);
 


### PR DESCRIPTION
The first command line argument passed to the test binary is considered a filter prefix: only test functions that match that prefix are run.