### PR TITLE
test: Add cross namespace C++ test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ add_compile_options(
     -Wextra
     -Wpedantic
     -Werror
-    -g
 )
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)


### PR DESCRIPTION
Expand coverage by ensure that backtraces work when working across namespaces.