### PR TITLE
Fix bug in backtrace_test:early_termination

### DIFF
--- a/test/backtrace_test.c
+++ b/test/backtrace_test.c
@@ -47,12 +47,12 @@ bool stop_after_n_frames_cb(uintptr_t addr, const char* fname, const char* sname
     BW_UNUSED(addr);
     BW_UNUSED(fname);
     BW_UNUSED(sname);
-
+    
     stop_context_t* ctx = arg;
+    ++ctx->fnum;
     if (ctx->fnum == ctx->fnum_max) {
         return false;
     }
-    ++ctx->fnum;
 
     return true;
 }


### PR DESCRIPTION
backtrace.early_termination fails because ctx->fnum is being incremented after the test to return false

1: RUN: backtrace.early_termination
1: [0x001db8] /home/kujawk/projects/backwalk/build/backtrace_test:early_termination
1: [0x0015b5] /home/kujawk/projects/backwalk/build/backtrace_test:main
1: [0x02724a] /lib/x86_64-linux-gnu/libc.so.6:?
1: /home/dillstead/projects/backwalk/test/backtrace_test.c:107
1: 	assertion failed: success == false
1: 	actual:   true
1: 	expected: false
1: END: backtrace.early_termination FAIL