### PR TITLE
core: Introduce signal-safe backtrace facility

### DIFF
--- a/.github/workflows/backwalk-ci.yml
+++ b/.github/workflows/backwalk-ci.yml
@@ -122,7 +122,11 @@ jobs:
               name: gcc-latest
             build_type:
               name: msan
-
+          - compiler:
+              name: gcc-latest
+            build_type:
+              name: tsan
+            os: ubuntu-24.04-arm
 
     steps:
     - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ configure_file(${BACKWALK_SRC_DIR}/version.c.in ${CMAKE_CURRENT_BINARY_DIR}/gen/
 # Source files
 set(BACKWALK_SRC_LIST
     ${BACKWALK_SRC_DIR}/backwalk.c
+    ${BACKWALK_SRC_DIR}/common.c
     ${BACKWALK_SRC_DIR}/context.c
     ${BACKWALK_SRC_DIR}/debug.c
     ${BACKWALK_SRC_DIR}/asm/context_aarch64.S
@@ -91,6 +92,9 @@ install(DIRECTORY ${BACKWALK_INCLUDE_DIR}/ DESTINATION include)
 function(bw_test TEST_NAME)
     file(GLOB TEST_FILE "${BACKWALK_TEST_DIR}/${TEST_NAME}.c*")
     add_executable(${TEST_NAME} ${TEST_FILE})
+    if (BW_DEBUG_ENABLED)
+        target_compile_definitions(${TEST_NAME} PRIVATE BW_DEBUG_ENABLED)
+    endif()
     target_include_directories(${TEST_NAME} PRIVATE ${BACKWALK_SRC_DIR} ${BACKWALK_TEST_DIR})
     target_link_libraries(${TEST_NAME} PRIVATE backwalk)
     target_link_options(${TEST_NAME} PRIVATE -rdynamic)
@@ -101,6 +105,8 @@ bw_test(backtrace_test)
 target_compile_options(backtrace_test BEFORE PRIVATE -fno-optimize-sibling-calls)
 bw_test(edge_cases_test)
 target_compile_options(edge_cases_test BEFORE PRIVATE -fno-optimize-sibling-calls)
+bw_test(signal_test)
+target_compile_options(signal_test BEFORE PRIVATE -fno-optimize-sibling-calls)
 bw_test(stress_test)
 bw_test(threading_test)
 target_link_libraries(threading_test PRIVATE pthread)

--- a/include/backwalk/backwalk.h
+++ b/include/backwalk/backwalk.h
@@ -2,9 +2,11 @@
 #define BW_BACKWALK_H
 
 #ifdef __cplusplus
+#include <cstddef>
 #include <cstdint>
 #else
 #include <stdbool.h>  // for bool
+#include <stddef.h>   // for size_t
 #include <stdint.h>   // for uintptr_t
 #endif
 
@@ -14,7 +16,17 @@ extern "C" {
 
 typedef bool (*bw_backtrace_cb)(uintptr_t addr, const char* fname, const char* sname, void* arg);
 
+typedef struct bw_context bw_context_t;
+
 bool bw_backtrace(bw_backtrace_cb cb, void* arg);
+
+bw_context_t* mkbw_context(size_t depth);
+
+void bw_context_fini(bw_context_t* ctx);
+
+bool bw_backtrace_collect(bw_context_t* ctx);
+
+bool bw_backtrace_process(bw_context_t* bw_ctx, bw_backtrace_cb cb, void* arg);
 
 #ifdef __cplusplus
 }

--- a/src/backwalk.c
+++ b/src/backwalk.c
@@ -4,11 +4,34 @@
 
 #include <dlfcn.h>    // for dladdr, Dl_info
 #include <stdbool.h>  // for bool, false, true
-#include <stddef.h>   // for NULL
+#include <stddef.h>   // for NULL, size_t
 #include <stdint.h>   // for uintptr_t
+#include <stdlib.h>   // for free, malloc
 
 #include "context.h"  // for context_get_ip, context_init, context_step, con...
 #include "debug.h"    // for BW_PRINT_FRAME
+
+static bool bw_frame_process(uintptr_t ip, bw_backtrace_cb cb, void* arg) {
+    Dl_info info;
+    uintptr_t mod_addr = 0;
+    const char* fname = NULL;
+    const char* sname = NULL;
+
+        // NOLINTNEXTLINE(performance-no-int-to-ptr)
+    if (dladdr((const void*)(ip - 1), &info)) {
+        mod_addr = ip - (uintptr_t)info.dli_fbase;
+    }
+    fname = info.dli_fname ? info.dli_fname : "?";
+    sname = info.dli_sname ? info.dli_sname : "?";
+
+    BW_PRINT_FRAME(mod_addr, fname, sname);
+
+    if (cb && !cb(mod_addr, fname, sname, arg)) {
+        return false;
+    }
+
+    return true;
+}
 
 bool bw_backtrace(bw_backtrace_cb cb, void* arg) {
     context_t ctx;
@@ -16,23 +39,72 @@ bool bw_backtrace(bw_backtrace_cb cb, void* arg) {
 
     while (context_step(&ctx)) {
         uintptr_t ip = context_get_ip(&ctx);
-        Dl_info info;
-        uintptr_t mod_addr = 0;
-        const char* fname = NULL;
-        const char* sname = NULL;
+        if (!bw_frame_process(ip, cb, arg)) {
+            return false;
+        };
+    }
 
-        // NOLINTNEXTLINE(performance-no-int-to-ptr)
-        if (dladdr((const void*)(ip - 1), &info)) {
-            mod_addr = ip - (uintptr_t)info.dli_fbase;
-        }
-        fname = info.dli_fname ? info.dli_fname : "?";
-        sname = info.dli_sname ? info.dli_sname : "?";
+    return true;
+}
 
-        BW_PRINT_FRAME(mod_addr, fname, sname);
+struct bw_context {
+    uintptr_t* ip;
+    size_t ip_cnt;
+    size_t ip_max_cnt;
+};
 
-        if (cb && !cb(mod_addr, fname, sname, arg)) {
+bw_context_t* mkbw_context(size_t depth) {
+    bw_context_t* bw_ctx = malloc(sizeof(bw_context_t));
+    if (bw_ctx == NULL) {
+        return NULL;
+    }
+    uintptr_t* ip = malloc(sizeof(uintptr_t) * depth);
+    if (ip == NULL) {
+        free(bw_ctx);
+        return NULL;
+    }
+
+    bw_ctx->ip = ip;
+    bw_ctx->ip_cnt = 0;
+    bw_ctx->ip_max_cnt = depth;
+
+    return bw_ctx;
+}
+
+void bw_context_fini(bw_context_t* bw_ctx) {
+    if (bw_ctx == NULL) {
+        return;
+    }
+
+    if (bw_ctx->ip != NULL) {
+        free(bw_ctx->ip);
+    }
+
+    free(bw_ctx);
+}
+
+bool bw_backtrace_collect(bw_context_t* bw_ctx) {
+    context_t ctx;
+    context_init(&ctx);
+    size_t ip_cnt = 0;
+
+    while (context_step(&ctx)) {
+        if (ip_cnt >= bw_ctx->ip_max_cnt) {
             return false;
         }
+        uintptr_t ip = context_get_ip(&ctx);
+        bw_ctx->ip[ip_cnt++] = ip;
+        bw_ctx->ip_cnt = ip_cnt;
+    }
+
+    return true;
+}
+
+bool bw_backtrace_process(bw_context_t* bw_ctx, bw_backtrace_cb cb, void* arg) {
+    for (size_t i = 0; i < bw_ctx->ip_cnt; ++i) {
+        if (!bw_frame_process(bw_ctx->ip[i], cb, arg)) {
+            return false;
+        };
     }
 
     return true;

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,27 @@
+#include "common.h"
+
+void ticket_init(ticket_t* ticket) {
+    ticket->cv = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
+    ticket->mtx = (pthread_mutex_t)PTHREAD_MUTEX_INITIALIZER;
+    ticket->state = false;
+}
+
+#define MUTEX_PROTECT(mutex, body)                                                                 \
+    BW_UNUSED(pthread_mutex_lock(mutex));                                                          \
+    do {                                                                                           \
+        body;                                                                                      \
+    } while (0);                                                                                   \
+    BW_UNUSED(pthread_mutex_unlock(mutex));
+
+void ticket_signal(ticket_t* ticket) {
+    MUTEX_PROTECT(&ticket->mtx, ticket->state = true);
+    BW_UNUSED(pthread_cond_signal(&ticket->cv));
+}
+
+void ticket_wait(ticket_t* ticket) {
+    MUTEX_PROTECT(&ticket->mtx, {
+        while (!ticket->state) {
+            BW_UNUSED(pthread_cond_wait(&ticket->cv, &ticket->mtx));
+        }
+    });
+}

--- a/src/common.h
+++ b/src/common.h
@@ -1,8 +1,25 @@
 #ifndef BW_COMMON_H
 #define BW_COMMON_H
 
+#include <pthread.h>  // for pthread_cond_t, pthread_mutex_t
+#ifndef __cplusplus
+#include <stdbool.h>  // for bool
+#endif
+
 #define BW_UNUSED(expr) (void)(expr)
 
 #define BW_ARRAY_LEN(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+typedef struct {
+    pthread_cond_t cv;
+    pthread_mutex_t mtx;
+    bool state;
+} ticket_t;
+
+void ticket_init(ticket_t* ticket);
+
+void ticket_signal(ticket_t* ticket);
+
+void ticket_wait(ticket_t* ticket);
 
 #endif // BW_COMMON_H

--- a/src/sanitizer.h
+++ b/src/sanitizer.h
@@ -1,7 +1,7 @@
 #ifndef BW_SANITIZER_H
 #define BW_SANITIZER_H
 
-#include "common.h"
+#include "common.h"  // for BW_UNUSED
 
 #ifdef __has_feature
 #if __has_feature(memory_sanitizer)

--- a/test/signal_test.c
+++ b/test/signal_test.c
@@ -1,0 +1,115 @@
+#include <errno.h>              // for errno
+#include <pthread.h>            // for pthread_create, pthread_join, pthread_t
+#include <signal.h>             // for size_t, raise, signal, SIGUSR1, SIG_ERR
+#include <stdbool.h>            // for bool, true
+#include <stdint.h>             // for uint8_t, uintptr_t
+#include <unistd.h>             // for _exit, NULL, close, pipe, read, write
+
+#include "common.h"             // for BW_UNUSED, ticket_init, ticket_signal
+#include "backwalk/backwalk.h"  // for bw_backtrace_collect, bw_backtrace_pr...
+
+#include "test.h"               // for TEST_ERROR_NONZERO, TEST_RESULT_ERR
+
+// _exit is async-signal-safe. See: https://man7.org/linux/man-pages/man7/signal-safety.7.html
+#define EXIT_IF(cond)                                                                              \
+    if ((cond) != 0) {                                                                             \
+        _exit(TEST_RESULT_ERR);                                                                    \
+    }
+
+#define EXIT_ON_NONZERO(f) EXIT_IF((f) != 0)
+
+typedef struct {
+    bw_context_t* backtrace_ctx;
+    int bt_collect_pipe[2];
+    pthread_t worker_th;
+    ticket_t worker_ready;
+} test_state_t;
+
+test_state_t test_state;
+
+static bool backtrace_cb(uintptr_t addr, const char* fname, const char* sname, void* arg) {
+    BW_UNUSED(addr);
+    BW_UNUSED(fname);
+    BW_UNUSED(sname);
+
+    size_t* frame_cnt = (size_t*)arg;
+    ++*frame_cnt;
+
+    return true;
+}
+
+void* backtrace_processor(void* arg) {
+    ticket_signal(&test_state.worker_ready);
+
+    uint8_t signal = 0;
+    // Wait for the signal handler's notification that the backtrace is ready for processing
+    EXIT_IF(read(test_state.bt_collect_pipe[0], &signal, sizeof(signal)) < 0);
+
+    EXIT_IF(!bw_backtrace_process(test_state.backtrace_ctx, backtrace_cb, arg));
+
+    return NULL;
+}
+
+void signal_handler(int signo) {
+    BW_UNUSED(signo);
+
+    // NOLINTNEXTLINE(bugprone-signal-handler)
+    EXIT_IF(!bw_backtrace_collect(test_state.backtrace_ctx));
+
+    uint8_t signal = 1;
+    EXIT_IF(write(test_state.bt_collect_pipe[1], &signal, sizeof(signal)) < 0);
+}
+
+__attribute__((noinline)) int raise_signal(int signo) {
+    if (raise(signo) != 0) {
+        return 1;
+    }
+
+    return 0;
+}
+
+#pragma GCC diagnostic push
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
+#pragma GCC diagnostic ignored "-Wc23-extensions"
+#endif
+TEST(safe_backtrace, {
+    TEST_ERROR_NONZERO(pipe(test_state.bt_collect_pipe));
+
+    ticket_init(&test_state.worker_ready);
+    size_t frame_cnt = 0;
+
+    TEST_ERROR_NONZERO(
+        pthread_create(&test_state.worker_th, NULL, backtrace_processor, &frame_cnt));
+
+    ticket_wait(&test_state.worker_ready);
+
+    test_state.backtrace_ctx = mkbw_context(16);
+    if (test_state.backtrace_ctx == NULL) {
+        // HACK: Not passing a variadic argument causes a C23-extension warning
+        TEST_ERROR("could not create backwalk context");
+    }
+
+    int signo = SIGUSR1;
+    if (signal(signo, signal_handler) == SIG_ERR) {
+        TEST_ERROR("could not install signal handler. errno=%d", errno);
+    }
+
+    TEST_ERROR_NONZERO(raise_signal(signo));
+
+    TEST_ERROR_NONZERO(pthread_join(test_state.worker_th, NULL));
+
+    TEST_ASSERT_GE_SIZE(frame_cnt, 1UL);
+    bw_context_fini(test_state.backtrace_ctx);
+    BW_UNUSED(close(test_state.bt_collect_pipe[1]));
+    BW_UNUSED(close(test_state.bt_collect_pipe[0]));
+})
+#pragma GCC diagnostic pop
+
+int main(int argc, char** argv) {
+    TEST_INIT("signal", argc, argv);
+
+    TEST_RUN(safe_backtrace);
+
+    TEST_EXIT();
+}

--- a/test/test.h
+++ b/test/test.h
@@ -161,11 +161,16 @@ typedef enum {
 
 #define TEST_FAIL() return TEST_RESULT_FAIL
 
+#define TEST_ERROR(fmt, ...)                                                                       \
+    do {                                                                                           \
+        TEST_LOG_("test error: " fmt __VA_OPT__(, ) __VA_ARGS__);                                  \
+        return TEST_RESULT_ERR;                                                                    \
+    } while (0)
+
 #define TEST_ERROR_NONZERO(expr)                                                                   \
     do {                                                                                           \
         if ((expr) != 0) {                                                                         \
-            TEST_LOG_("test error: %s == 0\n\tactual: %" PRId32 "\n", #expr, expr);                \
-            return TEST_RESULT_ERR;                                                                \
+            TEST_ERROR("%s == 0\n\tactual: %" PRId32 "\n", #expr, expr);                           \
         }                                                                                          \
     } while (0)
 


### PR DESCRIPTION
backwalk uses dladdr to resolve symbol addresses, which is not signal-safe. This patch introduces two APIs that decouple the backtrace collection from the processing phase. The collection API is signal-safe and can be called from a signal handler, while the processing API can be called later on a possibly separate thread. See signal_test.c for example usage.